### PR TITLE
Add saved preferences for timezone and wifi parameters

### DIFF
--- a/examples/factory/factory.ino
+++ b/examples/factory/factory.ino
@@ -19,10 +19,12 @@ extern void setupGui();
 
 static const char *ntpServer1 = "pool.ntp.org";
 static const char *ntpServer2 = "time.nist.gov";
-static const uint64_t  gmtOffset_sec = GMT_OFFSET_SECOND;
 static const int   daylightOffset_sec = 0;
 static SemaphoreHandle_t xSemaphore = NULL;
 
+String ssid;
+String sifipw;
+int8_t timezone;
 
 void instanceLockTake()
 {
@@ -60,7 +62,9 @@ void WiFiGotIP(WiFiEvent_t event, WiFiEventInfo_t info)
     Serial.println("WiFi connected");
     Serial.println("IP address: ");
     Serial.println(IPAddress(info.got_ip.ip_info.ip.addr));
-    configTime(gmtOffset_sec, daylightOffset_sec, ntpServer1, ntpServer2);
+    user_setting_params_t setting;
+    hw_get_user_setting(setting);
+    configTime(setting.gmtOffset_sec, daylightOffset_sec, ntpServer1, ntpServer2);
 }
 
 void setup()

--- a/examples/factory/hal_interface.cpp
+++ b/examples/factory/hal_interface.cpp
@@ -687,6 +687,7 @@ void hw_init()
         user_setting.disp_timeout_second = 30;
         user_setting.charger_current = DEVICE_CHARGE_CURRENT_RECOMMEND;
         user_setting.charger_enable = true;
+        user_setting.gmtOffset_sec = GMT_OFFSET_SECOND;
         prefs.putBytes(NVS_NAME, &user_setting, sizeof(user_setting_params_t));
     }
 
@@ -701,6 +702,9 @@ void hw_init()
             log_d("ON EVENT PMU CLICK");
         }
     }, POWER_EVENT, NULL);
+    
+    prefs.begin("my-config");
+    
 
 
 #else
@@ -725,6 +729,7 @@ void hw_get_user_setting(user_setting_params_t &param)
     printf("Get disp_timeout_second :%u\n", user_setting.disp_timeout_second);
     printf("Get charger_current     :%u\n", user_setting.charger_current);
     printf("Get charger_enable      :%u\n", user_setting.charger_enable);
+    printf("Get gmtOffset_sec       :%d\n", user_setting.gmtOffset_sec);
 }
 
 void hw_set_user_setting(user_setting_params_t &param)
@@ -738,7 +743,30 @@ void hw_set_user_setting(user_setting_params_t &param)
     printf("set disp_timeout_second :%u\n", param.disp_timeout_second);
     printf("set charger_current     :%u\n", param.charger_current);
     printf("set charger_enable      :%u\n", param.charger_enable);
+    printf("set gmtOffset_sec       :%d\n", param.gmtOffset_sec);
 
+}
+
+void hw_save_wifi_creds(const char *ssid, const char *password)
+{
+#ifdef ARDUINO
+    prefs.putString("wifi_ssid", ssid);
+    prefs.putString("wifi_password", password);
+    printf("Saved WiFi creds: ssid=%s\n", ssid);
+#endif
+}
+
+void hw_load_wifi_creds(char *ssid, size_t ssid_len, char *password, size_t password_len)
+{
+#ifdef ARDUINO
+    String s = prefs.getString("wifi_ssid", "");
+    String p = prefs.getString("wifi_password", "");
+    strncpy(ssid, s.c_str(), ssid_len - 1);
+    ssid[ssid_len - 1] = '\0';
+    strncpy(password, p.c_str(), password_len - 1);
+    password[password_len - 1] = '\0';
+    printf("Loaded WiFi creds: ssid=%s\n", ssid);
+#endif
 }
 
 const uint32_t hw_get_disp_timeout_ms()

--- a/examples/factory/hal_interface.h
+++ b/examples/factory/hal_interface.h
@@ -245,6 +245,7 @@ typedef struct {
     uint8_t disp_timeout_second;
     uint16_t charger_current;
     uint8_t charger_enable;
+    int32_t gmtOffset_sec;
 } user_setting_params_t;
 
 /**
@@ -833,6 +834,9 @@ void hw_get_user_setting(user_setting_params_t &param);
  * @param param A reference to a user_setting_params_t structure containing the new settings.
  */
 void hw_set_user_setting(user_setting_params_t &param);
+
+void hw_save_wifi_creds(const char *ssid, const char *password);
+void hw_load_wifi_creds(char *ssid, size_t ssid_len, char *password, size_t password_len);
 
 /**
  * @brief Get the display timeout in milliseconds.

--- a/examples/factory/ui_sys.cpp
+++ b/examples/factory/ui_sys.cpp
@@ -239,6 +239,39 @@ static lv_obj_t *create_subpage_otg(lv_obj_t *menu, lv_obj_t *main_page)
     return cont;
 }
 
+static const char *UTC_OFFSETS = "UTC-12\nUTC-11\nUTC-10\nUTC-9\nUTC-8\nUTC-7\nUTC-6\nUTC-5\nUTC-4\nUTC-3\nUTC-2\nUTC-1\nUTC+0\nUTC+1\nUTC+2\nUTC+3\nUTC+4\nUTC+5\nUTC+6\nUTC+7\nUTC+8\nUTC+9\nUTC+10\nUTC+11\nUTC+12\nUTC+13\nUTC+14";
+
+static int32_t utc_offset_to_index(int32_t offset_sec)
+{
+    return (offset_sec / 3600) + 12;
+}
+
+static int32_t utc_index_to_offset(int32_t index)
+{
+    return (index - 12) * 3600;
+}
+
+static void utc_offset_cb(lv_event_t *e)
+{
+    lv_obj_t *dd = (lv_obj_t *)lv_event_get_target(e);
+    uint16_t sel = lv_dropdown_get_selected(dd);
+    local_param.gmtOffset_sec = utc_index_to_offset(sel);
+}
+
+static lv_obj_t *create_subpage_time(lv_obj_t *menu, lv_obj_t *main_page)
+{
+    lv_obj_t *cont = lv_menu_cont_create(main_page);
+    lv_obj_t *label = lv_label_create(cont);
+    lv_label_set_text(label, LV_SYMBOL_SETTINGS" Time Settings");
+    lv_obj_t *sub_page = lv_menu_page_create(menu, NULL);
+
+    int32_t idx = utc_offset_to_index(local_param.gmtOffset_sec);
+    create_dropdown(sub_page, LV_SYMBOL_SETTINGS, "UTC Offset", UTC_OFFSETS, idx, utc_offset_cb);
+
+    lv_menu_set_load_page_event(menu, cont, sub_page);
+    return cont;
+}
+
 static lv_obj_t *create_subpage_info(lv_obj_t *menu, lv_obj_t *main_page)
 {
     lv_obj_t *btn;
@@ -388,6 +421,10 @@ void ui_sys_enter(lv_obj_t *parent)
     lv_obj_t *cont;
     // //! BACKLIGHT SETTING
     cont = create_subpage_backlight(menu, main_page);
+    lv_group_add_obj(menu_g, cont);
+
+    // //! TIME SETTINGS
+    cont = create_subpage_time(menu, main_page);
     lv_group_add_obj(menu_g, cont);
 
     // //! SYSTEM INFO

--- a/examples/factory/ui_wireless.cpp
+++ b/examples/factory/ui_wireless.cpp
@@ -133,9 +133,13 @@ static lv_obj_t *password_text_crate(lv_obj_t *parent)
     lv_obj_set_scrollbar_mode(pwd_ta, LV_SCROLLBAR_MODE_OFF);
 
 #ifdef WIFI_PASSWORD
-    lv_textarea_set_text(pwd_ta, WIFI_PASSWORD);
-    lv_strncpy(wifi_password, WIFI_PASSWORD, lv_strlen(WIFI_PASSWORD));
+    if (lv_strlen(wifi_password) == 0) {
+        lv_strncpy(wifi_password, WIFI_PASSWORD, sizeof(wifi_password) - 1);
+    }
 #endif
+    if (lv_strlen(wifi_password) > 0) {
+        lv_textarea_set_text(pwd_ta, wifi_password);
+    }
 
 #ifdef USING_TOUCHPAD
     keyboard = lv_keyboard_create(lv_scr_act());
@@ -164,6 +168,7 @@ static void wifi_connect_event(lv_event_t *e)
         params.ssid = wifi_ssid;
         params.password = wifi_password;
         hw_set_wifi_connect(params);
+        hw_save_wifi_creds(wifi_ssid, wifi_password);
         ui_show_wifi_process_bar();
     }
 }
@@ -198,13 +203,30 @@ static lv_obj_t *dropdown_create(lv_obj_t *parent)
     wifi_dd = lv_dropdown_create(parent);
     lv_dropdown_clear_options(wifi_dd);
     lv_obj_add_event_cb(wifi_dd, dropdown_event, LV_EVENT_VALUE_CHANGED, NULL);
+    int opt_idx = 0;
+    int sel_idx = 0;
 #ifdef WIFI_SSID
-    lv_dropdown_add_option(wifi_dd, WIFI_SSID, 0);
-    lv_strcpy(wifi_ssid, WIFI_SSID);
+    lv_dropdown_add_option(wifi_dd, WIFI_SSID, opt_idx);
+    if (lv_strlen(wifi_ssid) == 0) {
+        lv_strcpy(wifi_ssid, WIFI_SSID);
+        sel_idx = opt_idx;
+    } else if (lv_strcmp(wifi_ssid, WIFI_SSID) == 0) {
+        sel_idx = opt_idx;
+    }
+    opt_idx++;
 #endif
 #ifdef WIFI_SSID2
-    lv_dropdown_add_option(wifi_dd, WIFI_SSID2, 1);
+    lv_dropdown_add_option(wifi_dd, WIFI_SSID2, opt_idx);
+    if (lv_strcmp(wifi_ssid, WIFI_SSID2) == 0) {
+        sel_idx = opt_idx;
+    }
+    opt_idx++;
 #endif
+    if (lv_strlen(wifi_ssid) > 0 && sel_idx == 0) {
+        lv_dropdown_add_option(wifi_dd, wifi_ssid, opt_idx);
+        sel_idx = opt_idx;
+    }
+    lv_dropdown_set_selected(wifi_dd, sel_idx);
     return wifi_dd;
 }
 
@@ -268,6 +290,7 @@ static void scan_btn_event(lv_event_t *e)
 
 void ui_wireless_enter(lv_obj_t *parent)
 {
+    hw_load_wifi_creds(wifi_ssid, sizeof(wifi_ssid), wifi_password, sizeof(wifi_password));
     menu = create_menu(parent, back_event_handler);
 
     lv_obj_t *main_page = lv_menu_page_create(menu, NULL);


### PR DESCRIPTION
The factory firmware example source code has two major limitations:
- the timezone is hardcoded, so you have to recompile to change it.
- the wifi parameters are not saved, so you have to type in the password every time.

This patch:
- adds a gui to set the timezone.
- saves the timezone, and wifi parameters in the persistent preferences.